### PR TITLE
A few minor fixes, and add man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ options:
 	@echo "CFLAGS   = ${CFLAGS}"
 	@echo "LDFLAGS  = ${LDFLAGS}"
 	@echo "CC       = ${CC}"
-	@echo "LD       = ${LD}"
+#	@echo "LD       = ${LD}"
 
 .c.o:
 	@echo CC $<

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,12 @@ install: all
 	@mkdir -p ${DESTDIR}${PREFIX}/bin
 	@cp -f dzen2 ${DESTDIR}${PREFIX}/bin
 	@chmod 755 ${DESTDIR}${PREFIX}/bin/dzen2
+	@mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	@cp -f dzen2.1 ${DESTDIR}${MANPREFIX}/man1/dzen2.1
 
 uninstall:
 	@echo removing executable file from ${DESTDIR}${PREFIX}/bin
 	@rm -f ${DESTDIR}${PREFIX}/bin/dzen2
+	@rm -f ${DESTDIR}${MANPREFIX}/man1/dzen2.1
 
 .PHONY: all options clean dist install uninstall

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,7 @@ MANPREFIX = ${PREFIX}/share/man
 
 X11INC = /usr/X11R6/include
 X11LIB = /usr/X11R6/lib
-INCS = -I. -I/usr/include -I${X11INC}
+INCS = -I. -I${X11INC}
 
 # Configure the features you want to be supported
 # Only one of the following options has to be uncommented,
@@ -20,42 +20,42 @@ INCS = -I. -I/usr/include -I${X11INC}
 
 ## Option 1: No Xinerama no XPM no XFT
 #LIBS = -L${X11LIB} -lX11
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\"
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\"
 
 
 ## Option 2: No Xinerama with XPM
 #LIBS = -L${X11LIB} -lX11 -lXpm
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XPM
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XPM
 
 
 # Option 3: With Xinerama no XPM
 #LIBS = -L${X11LIB} -lX11 -lXinerama
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
 
 
 ## Option 4: With Xinerama and XPM
-#LIBS = -L${X11LIB} -lX11 -lXinerama -lXpm
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM
+LIBS = -L${X11LIB} -lX11 -lXinerama -lXpm
+CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM
 
 
 ## Option 5: With XFT
 #LIBS = -L${X11LIB} -lX11 `pkg-config --libs xft`
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 6: With XPM and XFT
 #LIBS = -L${X11LIB} -lX11 -lXpm `pkg-config --libs xft`
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 7: With Xinerama and XFT
 #LIBS = -L${X11LIB} -lX11 -lXinerama `pkg-config --libs xft`
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XFT `pkg-config --cflags xft`
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 8: With Xinerama and XPM and XFT
-LIBS = -L${X11LIB} -lX11 -lXinerama -lXpm `pkg-config --libs xft`
-CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
+#LIBS = -L${X11LIB} -lX11 -lXinerama -lXpm `pkg-config --libs xft`
+#CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
 
 
 

--- a/config.mk
+++ b/config.mk
@@ -19,50 +19,50 @@ INCS = -I. -I/usr/include -I${X11INC}
 # Comment  : Add # to the beginning of the respective lines
 
 ## Option 1: No Xinerama no XPM no XFT
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11
+#LIBS = -L${X11LIB} -lX11
 #CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\"
 
 
 ## Option 2: No Xinerama with XPM
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXpm
+#LIBS = -L${X11LIB} -lX11 -lXpm
 #CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XPM
 
 
 # Option 3: With Xinerama no XPM
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama
+#LIBS = -L${X11LIB} -lX11 -lXinerama
 #CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
 
 
 ## Option 4: With Xinerama and XPM
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama -lXpm
+#LIBS = -L${X11LIB} -lX11 -lXinerama -lXpm
 #CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM
 
 
 ## Option 5: With XFT
-LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 `pkg-config --libs xft`
-CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
+#LIBS = -L${X11LIB} -lX11 `pkg-config --libs xft`
+#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 6: With XPM and XFT
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXpm `pkg-config --libs xft`
+#LIBS = -L${X11LIB} -lX11 -lXpm `pkg-config --libs xft`
 #CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 7: With Xinerama and XFT
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama `pkg-config --libs xft`
+#LIBS = -L${X11LIB} -lX11 -lXinerama `pkg-config --libs xft`
 #CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 8: With Xinerama and XPM and XFT
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama -lXpm `pkg-config --libs xft`
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
+LIBS = -L${X11LIB} -lX11 -lXinerama -lXpm `pkg-config --libs xft`
+CFLAGS += -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`
 
 
 
 # END of feature configuration
 
 
-LDFLAGS = ${LIBS}
+LDFLAGS += ${LIBS}
 
 # Solaris, uncomment for Solaris
 #CFLAGS = -fast ${INCS} -DVERSION=\"${VERSION}\"
@@ -74,5 +74,5 @@ LDFLAGS = ${LIBS}
 #LDFLAGS = ${LIBS}
 
 # compiler and linker
-CC = gcc
+CC ?= gcc
 LD = ${CC}

--- a/dzen2.1
+++ b/dzen2.1
@@ -1,0 +1,95 @@
+.TH DZEN 1
+.SH NAME
+dzen2 \- general-purpose messaging and notification for X11
+.SH SYNOPSIS
+.B dzen2
+[\-v] [\-p [seconds]] [\-m [v|h]] [\-ta <l|c|r>] [\-sa <l|c|r>]
+      [\-x <pixel>] [\-y <pixel>] [\-w <pixel>] [\-tw <pixel>] [\-u] 
+      [\-e <string>] [\-l <lines>]  [\-fn <font>] [\-bg <color>]
+      [\-fg <color>] [\-xs <screen>]
+.SH DESCRIPTION
+.B Dzen
+is a general\-purpose messaging and notification program for X11,
+desigend to be scriptable in any language and integrate well with
+window managers like dwm, wmii and xmonad though it will work with any
+windowmanger.
+.PP
+.B Dzen
+expects the status message on its standard input, and uses a custom
+formatting language for colors and several other features (like bar
+meters and such). See README for detailed usage and scripting
+instructions.
+.SH OPTIONS
+.TP
+.B \-fg <color>
+Set foreground color. The <color> can be specified either as symbolic
+name (e.g. red, darkgreen, etc.) or as #rrggbb hex\-value
+(e.g. #ffffaa).
+.TP
+.B \-bg <color>
+Set background color (same format as \-fg).
+.TP
+.B \-fn <font>
+Set font (using the format of xlsfonts and xfontsel).
+.TP
+.B \-ta <l|c|r>
+Set alignement of title window content: l(eft), c(center) or r(ight).
+.TP
+.B \-tw <pixels>
+Set title window width.
+.TP
+.B \-sa <l|c|r>
+Set alignment of slave window (see
+.B \-ta
+).
+.TP
+.B \-l <lines>
+Number of lines to display in slave window (see (1) in README).
+.TP
+.B \-e <event1=action1:option1:...,action2;event2=...>
+Set up events and actions, eg. responses to mouse clicks (see (2) in README).
+.TP
+.B \-m
+Start up in menu mode (see (3) in README).
+.TP
+.B \-u
+Update contents of title and slave window simultaneously, see (see (4) in README).
+.TP
+.B \-p [<timeout>]
+Persist EOF (optional timeout in seconds).
+.TP
+.B \-x <pixels>
+Set x position on the screen.
+.TP
+.B \-y <pixels>
+Set y position on the screen.
+.TP
+.B \-h <pixels>
+Set line height (defaults to fontheight + 2 pixels).
+.TP
+.B \-w <pixels>
+width
+.TP
+.B \-xs <n>
+Set the Xinerama screen number where dzen should appear.
+.TP
+.B \-v
+Display version information.
+
+.SH AUTHOR
+.B Dzen2
+has been written by
+.B Robert Manea.
+This manpage has been written, based on dzen documentation, by Petr
+Ročkai, for Debian GNU/Linux, but may be used by others. This manpage
+falls under the same licence as Dzen2 itself, see 
+/usr/share/doc/dzen2/copyright.
+
+.SH SEE ALSO
+.BR dbar (1),
+.BR gcpubar (1),
+.BR gdbar (1),
+and
+.BR textwidth (1).
+More detailed documentation (especially on the formatting language of
+dzen2) is available in /usr/share/doc/dzen2/README.gz.

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -13,7 +13,7 @@ options:
 	@echo "CFLAGS   = ${CFLAGS}"
 	@echo "LDFLAGS  = ${LDFLAGS}"
 	@echo "CC       = ${CC}"
-	@echo "LD       = ${LD}"
+#	@echo "LD       = ${LD}"
 
 .c.o:
 	@echo CC $<

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -61,6 +61,12 @@ install: all
 	@chmod 755 ${DESTDIR}${PREFIX}/bin/gcpubar
 	@cp -f textwidth ${DESTDIR}${PREFIX}/bin
 	@chmod 755 ${DESTDIR}${PREFIX}/bin/textwidth
+	@echo install man pages to ${DESTDIR}${MANPREFIX}/man1
+	@mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	@cp -f dbar.1 ${DESTDIR}${MANPREFIX}/man1/dbar.1
+	@cp -f gdbar.1 ${DESTDIR}${MANPREFIX}/man1/gdbar.1
+	@cp -f gcpubar.1 ${DESTDIR}${MANPREFIX}/man1/gcpubar.1
+	@cp -f textwidth.1 ${DESTDIR}${MANPREFIX}/man1/textwidth.1
 
 uninstall:
 	@echo removing executable file from ${DESTDIR}${PREFIX}/bin
@@ -68,5 +74,10 @@ uninstall:
 	@rm -f ${DESTDIR}${PREFIX}/bin/gdbar
 	@rm -f ${DESTDIR}${PREFIX}/bin/gcpubar
 	@rm -f ${DESTDIR}${PREFIX}/bin/textwidth
+	@echo removing man pages from ${DESTDIR}${MANPREFIX}/man1
+	@rm -f ${DESTDIR}${MANPREFIX}/man1/dbar.1
+	@rm -f ${DESTDIR}${MANPREFIX}/man1/gdbar.1
+	@rm -f ${DESTDIR}${MANPREFIX}/man1/gcpubar.1
+	@rm -f ${DESTDIR}${MANPREFIX}/man1/textwidth.1
 
 .PHONY: all options clean install uninstall

--- a/gadgets/config.mk
+++ b/gadgets/config.mk
@@ -5,14 +5,14 @@ PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 
 X11INC = /usr/X11R6/include
-INCS = -I. -I/usr/include -I${X11INC}
+INCS = -I. -I${X11INC}
 
 X11LIB = /usr/X11R6/lib
-LIBS = -L/usr/lib 
+#LIBS = -L/usr/lib
 
-CFLAGS = -Os ${INCS} 
-LDFLAGS = ${LIBS}
+CFLAGS += -Os ${INCS}
+#LDFLAGS += ${LIBS}
 
 # compiler and linker
-CC = gcc
+CC ?= gcc
 LD = ${CC}

--- a/gadgets/dbar.1
+++ b/gadgets/dbar.1
@@ -1,0 +1,63 @@
+.TH "DBAR" 1 "Jan 01 2008"
+.SH NAME
+dbar \- simple gadget that you can use in combination with dzen to display a progressbar.
+.SH SYNOPSIS
+.HP 7
+\fBdbar\fR [\-w \fIcharacters\fR] [\-s \fIsymbol\fR] [\-min \fIminvalue\fR] [\-max \fImaxvalue\fR] [\-l \fIstring\fR] [\-nonl]
+.SH DESCRIPTION
+.B dbar
+is an application that generates semi graphical progress meters, from some values you supply to it.
+.PP
+See the usage examples for a description of the expected input format.
+.SH OPTIONS
+A summary of options is included below.
+.TP
+.B \-max
+Value to be considered 100% (default: 100)
+.TP
+.B \-min
+Value to be considered 0% (default: 0)
+.TP
+.B \-w
+Number of charcaters to be considered 100% in the bar  (default: 25 )
+.TP
+.B \-s
+Symbol represeting the percentage value in the bar (default: =  )
+.TP
+.B \-l
+label to be prepended to the bar (default: '' )
+.TP
+.B \-nonl
+no new line, don't put '\n' at the end of the bar    (default: do print '\n')
+.SH USAGE EXAMPLES
+.TP
+.B Static 0% and 100% mark or single value input:
+.IP
+Command: echo 25 | dbar \-m 100 \-l Sometext
+.br
+Output: Sometext  25% [======                   ]
+.TP
+.B If your 100% mark changes dynamically or 2-values input:
+.IP
+Command: echo "50 150" | dbar
+.br
+Output: 33% [========                 ]
+.TP
+.B If your value range is not between [0, maxval] or 3-values input:
+.IP
+Command: echo "50 \-25 150" | dbar
+.br
+Output: 43% [===========              ]
+.PP
+.SH AUTHOR
+.B Dbar
+was written by Robert Manea.
+.PP
+This manual page was written by bertagaz <bertagaz@ptitcanardnoir.org>,
+for the Debian project (but may be used by others).
+.SH SEE ALSO
+.BR dzen2 (1),
+.BR gcpubar (1),
+.BR gdbar (1),
+and
+.BR textwidth (1).

--- a/gadgets/gcpubar.1
+++ b/gadgets/gcpubar.1
@@ -1,0 +1,44 @@
+.TH "GCPUBAR" 1 "Jan 01 2008"
+.SH NAME
+gcpubar \- graphical CPU usage meter
+.SH SYNOPSIS
+.HP 7
+\fBgcpubar\fR [\-i \fIinterval\fR] [\-c \fIcount\fR] [\-fg \fIcolor\fR] [\-bg \fIcolor\fR] [\-w \fIpixel\fR] [\-h\ \fIpixel\fR] [\-nonl]
+.SH DESCRIPTION
+.B gcpubar
+is a CPU utilization meter for Linux. It relies on the existence of the /proc/stat file and generates fully graphical meters viewable with dzen.
+.SH OPTIONS
+A summary of options is included below.
+.TP
+.B \-i
+Update interval in seconds (default 1). You can use positive values less than 1 for intervals shorter than 1 second.
+.TP
+.B \-c
+Terminate after displaying argument to this option (default infinite).
+.TP
+.B \-fg
+Foreground color
+.TP
+.B \-bg
+Background color
+.TP
+.B \-w
+Width in piwels
+.TP
+.B \-h
+Height in pixels
+.TP
+.B \-nonl
+No new line, don't put '\\n' at the end of the bar (default: do print '\\n')
+.SH AUTHOR
+.B gcpubar
+was written by Robert Manea.
+.PP
+This manual page was written by bertagaz <bertagaz@ptitcanardnoir.org>,
+for the Debian project (but may be used by others).
+.SH SEE ALSO
+.BR dzen2 (1),
+.BR dbar (1),
+.BR gdbar (1),
+and
+.BR textwidth (1).

--- a/gadgets/gdbar.1
+++ b/gadgets/gdbar.1
@@ -1,0 +1,59 @@
+.TH "GDBAR" 1 "Jan 01 2008"
+.SH NAME
+gdbar \- generates fully graphical progress meters
+.SH SYNOPSIS
+.HP 7
+\fBgdbar\fR [\-w \fIcharacters\fR] [\-s \fIsymbol\fR] [\-fg \fIcolor\fR] [\-bg \fIcolor\fR] [\-min \fIminvalue\fR] [\-max \fImaxvalue\fR] [\-l \fIstring\fR] [\-nonl] [\-o]
+.SH DESCRIPTION
+.B gdbar
+application that generates fully graphical progress meters, from some values you supply to it.
+.PP
+It has the same input semantics as dbar (see 
+.B dbar (1)
+\). In contrast to dbar, gdbar draws fully graphical meters which are only useful in combination with dzen.
+.PP
+See the usage examples for a description of the expected input format.
+.SH OPTIONS
+A summary of options is included below.
+.TP
+.B \-max
+Value to be considered 100% (default: 100)
+.TP
+.B \-min
+Value to be considered 0% (default: 0)
+.TP
+.B \-fg
+Foreground color. (default white)
+.TP
+.B \-bg
+Bacground color (default darkgrey)
+.TP
+.B \-w
+Size in pixels to be considered 100% in the bar  (default: 80 )
+.TP
+.B \-h
+Bar height.
+.TP
+.B \-l
+label to be prepended to the bar (default: '' )
+.TP
+.B \-o
+Draw conky style meters.
+.TP
+.B \-nonl
+no new line, don't put '\n' at the end of the bar (default: do
+print '\n')
+
+.SH AUTHOR
+.B Dbar
+was written by Robert Manea.
+.PP
+This manual page was written by bertagaz <bertagaz@ptitcanardnoir.org>,
+for the Debian project (but may be used by others).
+
+.SH SEE ALSO
+.BR dzen2 (1),
+.BR dbar (1),
+.BR gcpubar (1),
+and
+.BR textwidth (1).

--- a/gadgets/textwidth.1
+++ b/gadgets/textwidth.1
@@ -1,0 +1,33 @@
+.TH "TEXTWIDTH" 1 "Jan 01 2008"
+.SH NAME
+textwidth \- calculate the width in pixels of text for a given font.
+.SH SYNOPSIS
+.HP 7
+\fBtextwidth\fR  \fIfontname\fR \fIstring\fR
+.SH DESCRIPTION
+.B textwidth
+is a simple utility to calculate the width in pixels of text with a given font.
+.PP
+This tool is provided as part of the
+.B dzen2 (1)
+package.
+.SH OPTIONS
+A summary of options is included below.
+.TP
+.B fontname
+Set the font.
+.TP
+.B string
+Set the string. 
+.SH AUTHOR
+.B textwidth
+was written by Robert Manea.
+.PP
+This manual page was written by bertagaz <bertagaz@ptitcanardnoir.org>,
+for the Debian project (but may be used by others).
+.SH SEE ALSO
+.BR dzen2 (1),
+.BR dbar (1),
+.BR gcpubar (1),
+and
+.BR gdbar (1).

--- a/main.c
+++ b/main.c
@@ -1046,14 +1046,14 @@ main(int argc, char *argv[]) {
 			printf("dzen-"VERSION", (C)opyright 2007-2009 Robert Manea\n");
 			printf(
 			"Enabled optional features: "
-#ifdef DZEN_XMP
-			" XPM "
+#ifdef DZEN_XPM
+			"XPM "
 #endif
 #ifdef DZEN_XFT
-			" XFT"
+			"XFT "
 #endif
 #ifdef DZEN_XINERAMA
-			" XINERAMA "
+			"XINERAMA "
 #endif
 			"\n"
 			);
@@ -1062,7 +1062,7 @@ main(int argc, char *argv[]) {
 		else
 			eprint("usage: dzen2 [-v] [-p [seconds]] [-m [v|h]] [-ta <l|c|r>] [-sa <l|c|r>]\n"
                    "             [-x <pixel>] [-y <pixel>] [-w <pixel>] [-h <pixel>] [-tw <pixel>] [-u]\n"
-				   "             [-e <string>] [-l <lines>]  [-fn <font>] [-bg <color>] [-fg <color>]\n"
+				   "             [-e <string>] [-l <lines>] [-fn <font>] [-bg <color>] [-fg <color>]\n"
 				   "             [-geometry <geometry string>] [-expand <left|right>] [-dock]\n"
 				   "             [-title-name <string>] [-slave-name <string>]\n"
 #ifdef DZEN_XINERAMA


### PR DESCRIPTION
I 'borrowed' the man pages from Debian (permission is given for use in other places at the bottom of each one).

There was a typo in an IFDEF that meant XPM support was never shown in dzen2 -v

The makefile changes are to be more adaptable to people's environments (cflags, cc, lib dir, etc)